### PR TITLE
fix(ci): set Kustomize newName/newTag in dev promotion

### DIFF
--- a/.github/workflows/ci-publish-image.yml
+++ b/.github/workflows/ci-publish-image.yml
@@ -73,6 +73,7 @@ jobs:
       DEPLOY_REPO: pipeops-platform/devops-lab-deploy
       DEPLOY_BASE_BRANCH: main
       DEPLOY_FILE: apps/devops-lab-app/overlays/dev/kustomization.yaml
+      DEPLOY_IMAGE_NAME: pipeops/devops-lab-app
       NEW_IMAGE_REPO: ${{ secrets.RUNTIME_IMAGE_REPO != '' && secrets.RUNTIME_IMAGE_REPO || format('ghcr.io/{0}', github.repository) }}
       NEW_TAG: ${{ needs.publish.outputs.image_tag }}
 
@@ -119,6 +120,7 @@ jobs:
 
           file_path = Path("apps/devops-lab-app/overlays/dev/kustomization.yaml")
           content = file_path.read_text(encoding="utf-8")
+          deploy_image_name = "${{ env.DEPLOY_IMAGE_NAME }}".strip()
           new_image_repo = "${{ env.NEW_IMAGE_REPO }}".strip()
           if not new_image_repo:
             current_name_match = re.search(r'(?m)^\s*-\s*name:\s*(.+)$', content)
@@ -127,7 +129,16 @@ jobs:
             new_image_repo = current_name_match.group(1).strip()
           new_tag = "${{ env.NEW_TAG }}"
 
-          updated = re.sub(r'(?m)^(\s*-\s*name:\s*).*$' , rf'\1{new_image_repo}', content)
+          updated = re.sub(r'(?m)^(\s*-\s*name:\s*).*$' , rf'\1{deploy_image_name}', content)
+          if re.search(r'(?m)^\s*newName:\s*.+$', updated):
+            updated = re.sub(r'(?m)^(\s*newName:\s*).+$', rf'\1{new_image_repo}', updated)
+          else:
+            updated = re.sub(
+              r'(?m)^(\s*)-\s*name:\s*.+$',
+              rf'\1- name: {deploy_image_name}\n\1  newName: {new_image_repo}',
+              updated,
+              count=1,
+            )
           updated = re.sub(r'(?m)^(\s*newTag:\s*").*(")\s*$', rf'\1{new_tag}\2', updated)
           if content == updated:
             print("No tag change detected")


### PR DESCRIPTION
Keeps image name anchored to base Kustomize name and writes runtime repository to newName, preventing no-op image transforms in deploy overlay updates.