### PR TITLE
refactor(ci): close deploy-request PR after dispatch, skip unnecessary runs

### DIFF
--- a/.github/workflows/ci-deploy-on-app-pr-approval.yml
+++ b/.github/workflows/ci-deploy-on-app-pr-approval.yml
@@ -105,10 +105,11 @@ jobs:
           echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
           echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
 
-      - name: Mark PR as dispatched
+      - name: Close PR and clean up
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
           WORKFLOW_NAME: ${{ steps.dispatch.outputs.workflow_name }}
           RUN_URL: ${{ steps.dispatch.outputs.run_url }}
           OPERATION: ${{ steps.parse.outputs.operation }}
@@ -116,7 +117,9 @@ jobs:
         run: |
           gh label create "deploy-operation-dispatched" --repo "$GITHUB_REPOSITORY" --color "1f6feb" --description "Deploy request already dispatched" --force
           gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "deploy-operation-dispatched"
-          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "✅ Approved and dispatched **${OPERATION}** for **${TARGET_ENV}**.\n\n- Workflow: ${WORKFLOW_NAME}\n- Run: ${RUN_URL}"
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "✅ Approved and dispatched **${OPERATION}** for **${TARGET_ENV}**.\n\n- Workflow: ${WORKFLOW_NAME}\n- Run: ${RUN_URL}\n\nThis PR served as an approval gate and will be closed without merging."
+          gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+          git push origin --delete "$BRANCH" 2>/dev/null || true
 
       - name: Comment back on source issue
         env:

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '.github/deploy-requests/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-publish-image.yml
+++ b/.github/workflows/ci-publish-image.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.github/deploy-requests/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Close deploy-request PR after dispatch (approval gate only, no merge needed)
- Delete request branch after close
- Add paths-ignore for deploy-requests in PR Checks and Publish Image

## Why
Eliminates 2 unnecessary runs per deploy-request:
- **PR Checks**: lint/test on JSON-only PR
- **Publish Image**: Docker build on merge of deploy-request files

## New flow (5 runs total)
1. Issue opened -> creates app PR (gate)
2. Human approves PR -> dispatches promote/rollback
3. CI Promote/Rollback -> dispatches deploy repo
4. Deploy repo -> creates PR + auto-merge
5. App PR **closed** (not merged)