### PR TITLE
feat: issue feedback on deploy (comment + auto-close)

### DIFF
--- a/.github/workflows/ci-promote-environment.yml
+++ b/.github/workflows/ci-promote-environment.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   plan:
@@ -171,3 +172,50 @@ jobs:
 
           echo "Watching deploy workflow run id: $RUN_ID"
           gh run watch --repo "$DEPLOY_REPO" "$RUN_ID" --exit-status
+
+  issue-feedback:
+    name: Update source issue
+    needs: [promote-staging, promote-production]
+    if: always() && startsWith(inputs.correlation_id, 'issue-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment and close issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          TARGET_ENV: ${{ inputs.target_env }}
+          STAGING_RESULT: ${{ needs.promote-staging.result }}
+          PROD_RESULT: ${{ needs.promote-production.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ISSUE_NUMBER=$(echo "$CORRELATION_ID" | sed -E 's/^issue-([0-9]+)-.*/\1/')
+          if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "$CORRELATION_ID" ]; then
+            echo "Could not extract issue number from correlation_id"
+            exit 0
+          fi
+
+          DEPLOY_RESULT="skipped"
+          if [ "$STAGING_RESULT" = "success" ] || [ "$PROD_RESULT" = "success" ]; then
+            DEPLOY_RESULT="success"
+          elif [ "$STAGING_RESULT" = "failure" ] || [ "$PROD_RESULT" = "failure" ]; then
+            DEPLOY_RESULT="failure"
+          elif [ "$STAGING_RESULT" = "cancelled" ] || [ "$PROD_RESULT" = "cancelled" ]; then
+            DEPLOY_RESULT="cancelled"
+          fi
+
+          if [ "$DEPLOY_RESULT" = "success" ]; then
+            gh label create "deploy-succeeded" --repo "$GITHUB_REPOSITORY" --color "0e8a16" --description "Deploy completed successfully" --force
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "$(printf '✅ **Deploy de promotion concluído com sucesso!**\n\n- Target: **%s**\n- Run: %s\n\nIssue fechada automaticamente.' "$TARGET_ENV" "$RUN_URL")"
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "deploy-succeeded"
+            gh issue close "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --reason completed
+          elif [ "$DEPLOY_RESULT" = "failure" ]; then
+            gh label create "deploy-failed" --repo "$GITHUB_REPOSITORY" --color "d73a4a" --description "Deploy failed" --force
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "$(printf '❌ **Deploy de promotion falhou.**\n\n- Target: **%s**\n- Run: %s\n\nVerifique os logs e crie uma nova issue se necessário.' "$TARGET_ENV" "$RUN_URL")"
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "deploy-failed"
+          elif [ "$DEPLOY_RESULT" = "cancelled" ]; then
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "$(printf '⚠️ **Deploy de promotion cancelado.**\n\n- Target: **%s**\n- Run: %s' "$TARGET_ENV" "$RUN_URL")"
+          fi

--- a/.github/workflows/ci-rollback-environment.yml
+++ b/.github/workflows/ci-rollback-environment.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   gate:
@@ -136,3 +137,50 @@ jobs:
           fi
 
           gh run watch --repo "$DEPLOY_REPO" "$RUN_ID" --exit-status
+
+  issue-feedback:
+    name: Update source issue
+    needs: [rollback-staging, rollback-production]
+    if: always() && startsWith(inputs.correlation_id, 'issue-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment and close issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          TARGET_ENV: ${{ inputs.target_env }}
+          STAGING_RESULT: ${{ needs.rollback-staging.result }}
+          PROD_RESULT: ${{ needs.rollback-production.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ISSUE_NUMBER=$(echo "$CORRELATION_ID" | sed -E 's/^issue-([0-9]+)-.*/\1/')
+          if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "$CORRELATION_ID" ]; then
+            echo "Could not extract issue number from correlation_id"
+            exit 0
+          fi
+
+          DEPLOY_RESULT="skipped"
+          if [ "$STAGING_RESULT" = "success" ] || [ "$PROD_RESULT" = "success" ]; then
+            DEPLOY_RESULT="success"
+          elif [ "$STAGING_RESULT" = "failure" ] || [ "$PROD_RESULT" = "failure" ]; then
+            DEPLOY_RESULT="failure"
+          elif [ "$STAGING_RESULT" = "cancelled" ] || [ "$PROD_RESULT" = "cancelled" ]; then
+            DEPLOY_RESULT="cancelled"
+          fi
+
+          if [ "$DEPLOY_RESULT" = "success" ]; then
+            gh label create "deploy-succeeded" --repo "$GITHUB_REPOSITORY" --color "0e8a16" --description "Deploy completed successfully" --force
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "$(printf '✅ **Rollback concluído com sucesso!**\n\n- Target: **%s**\n- Run: %s\n\nIssue fechada automaticamente.' "$TARGET_ENV" "$RUN_URL")"
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "deploy-succeeded"
+            gh issue close "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --reason completed
+          elif [ "$DEPLOY_RESULT" = "failure" ]; then
+            gh label create "deploy-failed" --repo "$GITHUB_REPOSITORY" --color "d73a4a" --description "Deploy failed" --force
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "$(printf '❌ **Rollback falhou.**\n\n- Target: **%s**\n- Run: %s\n\nVerifique os logs e crie uma nova issue se necessário.' "$TARGET_ENV" "$RUN_URL")"
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "deploy-failed"
+          elif [ "$DEPLOY_RESULT" = "cancelled" ]; then
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "$(printf '⚠️ **Rollback cancelado.**\n\n- Target: **%s**\n- Run: %s' "$TARGET_ENV" "$RUN_URL")"
+          fi


### PR DESCRIPTION
## Summary

Adds an **issue-feedback** job to both promote and rollback workflows that:

- **On success**: comments with a checkmark, adds deploy-succeeded label, and auto-closes the issue
- **On failure**: comments with an error summary and adds deploy-failed label
- **On cancelled**: comments with a warning

Only runs when the correlation_id starts with issue- (originating from the issue orchestrator).

### Files changed
- .github/workflows/ci-promote-environment.yml — added issue-feedback job + issues: write permission
- .github/workflows/ci-rollback-environment.yml — added issue-feedback job + issues: write permission