### PR TITLE
feat(rollback): permitir selecionar versão no issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/rollback-deploy.yml
+++ b/.github/ISSUE_TEMPLATE/rollback-deploy.yml
@@ -18,6 +18,14 @@ body:
         - prod-green
     validations:
       required: true
+  - type: input
+    id: rollback_version
+    attributes:
+      label: Rollback version (optional)
+      description: Informe a tag de versão para rollback (ex: sha-abc123...). Deixe em branco para voltar para o previous stable.
+      placeholder: sha-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    validations:
+      required: false
   - type: textarea
     id: incident
     attributes:

--- a/.github/workflows/ci-deploy-on-app-pr-approval.yml
+++ b/.github/workflows/ci-deploy-on-app-pr-approval.yml
@@ -40,10 +40,17 @@ jobs:
               raise SystemExit(f"Missing deploy metadata key: {key}")
             return match.group(1).strip()
 
+          def read_optional_value(key: str) -> str:
+            match = re.search(rf"(?im)^\s*{re.escape(key)}:\s*(.*?)\s*$", body)
+            if not match:
+              return ""
+            return match.group(1).strip()
+
           operation = read_value("operation")
           target_env = read_value("target_env")
           correlation_id = read_value("correlation_id")
           issue_number = read_value("issue_number")
+          rollback_version = read_optional_value("rollback_version")
 
           if operation not in {"promote", "rollback"}:
             raise SystemExit(f"Unsupported operation in metadata: {operation}")
@@ -56,6 +63,7 @@ jobs:
             output.write(f"target_env={target_env}\n")
             output.write(f"correlation_id={correlation_id}\n")
             output.write(f"issue_number={issue_number}\n")
+            output.write(f"rollback_version={rollback_version}\n")
           PY
 
       - name: Dispatch requested workflow
@@ -66,6 +74,7 @@ jobs:
           TARGET_ENV: ${{ steps.parse.outputs.target_env }}
           CORRELATION_ID: ${{ steps.parse.outputs.correlation_id }}
           ISSUE_NUMBER: ${{ steps.parse.outputs.issue_number }}
+          ROLLBACK_VERSION: ${{ steps.parse.outputs.rollback_version }}
           REPO: ${{ github.repository }}
         run: |
           if [ "$OPERATION" = "promote" ]; then
@@ -74,11 +83,20 @@ jobs:
             WORKFLOW_NAME="CI - Rollback Environment"
           fi
 
-          gh workflow run "$WORKFLOW_NAME" \
-            --repo "$REPO" \
-            --ref "main" \
-            -f target_env="$TARGET_ENV" \
-            -f correlation_id="$CORRELATION_ID"
+          if [ "$OPERATION" = "rollback" ] && [ -n "$ROLLBACK_VERSION" ]; then
+            gh workflow run "$WORKFLOW_NAME" \
+              --repo "$REPO" \
+              --ref "main" \
+              -f target_env="$TARGET_ENV" \
+              -f correlation_id="$CORRELATION_ID" \
+              -f rollback_version="$ROLLBACK_VERSION"
+          else
+            gh workflow run "$WORKFLOW_NAME" \
+              --repo "$REPO" \
+              --ref "main" \
+              -f target_env="$TARGET_ENV" \
+              -f correlation_id="$CORRELATION_ID"
+          fi
 
           RUN_ID=""
           for _ in $(seq 1 60); do

--- a/.github/workflows/ci-issue-deploy-operations.yml
+++ b/.github/workflows/ci-issue-deploy-operations.yml
@@ -57,6 +57,13 @@ jobs:
           if target_env not in allowed:
             raise SystemExit(f"Unsupported target environment: {target_env!r}")
 
+          rollback_version = ""
+          rollback_match = re.search(r"(?im)^###\s*Rollback version \(optional\)\s*$\s*([\s\S]*?)(?:^###\s|\Z)", issue_body)
+          if rollback_match:
+            rollback_version = next((line.strip() for line in rollback_match.group(1).splitlines() if line.strip()), "")
+          if operation == "promote":
+            rollback_version = ""
+
           issue_number = os.environ.get("ISSUE_NUMBER", "0")
           correlation_id = f"issue-{issue_number}-{operation}-{target_env}"
 
@@ -67,6 +74,7 @@ jobs:
             output.write(f"correlation_id={correlation_id}\n")
             output.write(f"issue_number={issue_number}\n")
             output.write(f"issue_title={issue_title}\n")
+            output.write(f"rollback_version={rollback_version}\n")
           PY
 
       - name: Checkout app repo
@@ -81,6 +89,7 @@ jobs:
           CORRELATION_ID: ${{ steps.parse.outputs.correlation_id }}
           ISSUE_NUMBER: ${{ steps.parse.outputs.issue_number }}
           ISSUE_TITLE: ${{ steps.parse.outputs.issue_title }}
+          ROLLBACK_VERSION: ${{ steps.parse.outputs.rollback_version }}
         run: |
           REQUEST_DIR=".github/deploy-requests"
           REQUEST_FILE="$REQUEST_DIR/${CORRELATION_ID}.json"
@@ -94,6 +103,7 @@ jobs:
             "issue_title": "${ISSUE_TITLE//"/\"}",
             "operation": "${OPERATION}",
             "target_env": "${TARGET_ENV}",
+            "rollback_version": "${ROLLBACK_VERSION//"/\"}",
             "correlation_id": "${CORRELATION_ID}",
             "requested_by": "${{ github.actor }}"
           }
@@ -134,12 +144,14 @@ jobs:
 
           - Operation: ${OPERATION}
           - Target environment: ${TARGET_ENV}
+          - Rollback version: ${ROLLBACK_VERSION:-previous-stable}
           - Requested by: ${{ github.actor }}
 
           <!-- deploy-operation-metadata
           issue_number: ${ISSUE_NUMBER}
           operation: ${OPERATION}
           target_env: ${TARGET_ENV}
+          rollback_version: ${ROLLBACK_VERSION}
           correlation_id: ${CORRELATION_ID}
           request_file: ${REQUEST_FILE}
           -->

--- a/.github/workflows/ci-rollback-environment.yml
+++ b/.github/workflows/ci-rollback-environment.yml
@@ -17,6 +17,10 @@ on:
         description: Correlation id from issue orchestrator (optional)
         required: false
         type: string
+      rollback_version:
+        description: Optional image tag to rollback to (e.g. sha-...); when empty uses previous stable
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -58,6 +62,7 @@ jobs:
           TARGET_ENV: ${{ inputs.target_env }}
           CORRELATION_ID: ${{ inputs.correlation_id != '' && inputs.correlation_id || format('app-rollback-{0}-{1}', github.run_id, github.job) }}
           REQUESTED_BY: ${{ github.actor }}
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
         run: |
           WORKFLOW_NAME="Rollback Environment"
 
@@ -66,7 +71,8 @@ jobs:
             --ref "$DEPLOY_BASE_BRANCH" \
             -f target_env="$TARGET_ENV" \
             -f requested_by="$REQUESTED_BY" \
-            -f correlation_id="$CORRELATION_ID"
+            -f correlation_id="$CORRELATION_ID" \
+            -f rollback_version="$ROLLBACK_VERSION"
 
           RUN_ID=""
           for _ in $(seq 1 60); do
@@ -106,6 +112,7 @@ jobs:
           TARGET_ENV: ${{ inputs.target_env }}
           CORRELATION_ID: ${{ inputs.correlation_id != '' && inputs.correlation_id || format('app-rollback-{0}-{1}', github.run_id, github.job) }}
           REQUESTED_BY: ${{ github.actor }}
+          ROLLBACK_VERSION: ${{ inputs.rollback_version }}
         run: |
           WORKFLOW_NAME="Rollback Environment"
 
@@ -114,7 +121,8 @@ jobs:
             --ref "$DEPLOY_BASE_BRANCH" \
             -f target_env="$TARGET_ENV" \
             -f requested_by="$REQUESTED_BY" \
-            -f correlation_id="$CORRELATION_ID"
+            -f correlation_id="$CORRELATION_ID" \
+            -f rollback_version="$ROLLBACK_VERSION"
 
           RUN_ID=""
           for _ in $(seq 1 60); do


### PR DESCRIPTION
## Problema
Rollback por issue falha quando não existe previous stable no histórico do ambiente (ex.: staging com histórico curto).

## Solução no app
- Adiciona campo opcional Rollback version (optional) no issue template
- Parseia ollback_version do issue e inclui no metadata da PR de aprovação
- Encaminha ollback_version para o workflow CI - Rollback Environment
- Mantém comportamento atual quando o campo fica vazio

## Observação
Essa PR deve ser combinada com a PR correspondente no repo deploy para aplicar a resolução completa ponta a ponta.