### PR TITLE
fix: rollback issue template not showing in chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: DevOps Lab Hub Documentation
-    url: https://github.com/flaviopiccolo-boop/devops-lab-hub
+    url: https://github.com/pipeops-platform/devops-lab-hub
     about: Check standards, runbooks, and phase documentation before opening a deploy operation issue.

--- a/.github/ISSUE_TEMPLATE/rollback-deploy.yml
+++ b/.github/ISSUE_TEMPLATE/rollback-deploy.yml
@@ -21,9 +21,9 @@ body:
   - type: input
     id: rollback_version
     attributes:
-      label: Rollback version (optional)
-      description: Informe a tag de versão para rollback (ex: sha-abc123...). Deixe em branco para voltar para o previous stable.
-      placeholder: sha-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      label: "Rollback version (optional)"
+      description: "Specify the image tag to rollback to (e.g. sha-abc1234). Leave blank to use the previous stable version."
+      placeholder: "sha-abc1234"
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Fixes rollback template not appearing in GitHub issue chooser.

Changes:
- Replaced Portuguese description with English in rollback-deploy.yml input field
- Quoted label and description values to ensure YAML safety  
- Fixed config.yml org URL (flaviopiccolo-boop -> pipeops-platform)